### PR TITLE
Update Client.js - Add multiple selectors from authenticated page.

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -172,15 +172,17 @@ class Client extends EventEmitter {
             }
         );
 
-        const INTRO_IMG_SELECTOR = '[data-icon=\'chat\']';
+        const INTRO_IMG_SELECTOR = ['[data-icon*=community]', '[data-icon*=status]', '[data-icon*=community]', '[data-icon*=chat]', '[data-icon*=back]', '[data-icon*=search]', '[data-icon*=filter]', '[data-icon*=lock-small]', '[data-icon*=chat]', 'div[role*=textbox]'];
         const INTRO_QRCODE_SELECTOR = 'div[data-ref] canvas';
 
         // Checks which selector appears first
         const needAuthentication = await Promise.race([
             new Promise(resolve => {
-                page.waitForSelector(INTRO_IMG_SELECTOR, { timeout: this.options.authTimeoutMs })
-                    .then(() => resolve(false))
-                    .catch((err) => resolve(err));
+                page.waitForFunction((INTRO_IMG_SELECTOR) => 
+                    !!document.querySelectorAll(INTRO_IMG_SELECTOR).length, {}, INTRO_IMG_SELECTOR
+                )
+                .then(() => resolve(false))
+                .catch((err) => resolve(err));
             }),
             new Promise(resolve => {
                 page.waitForSelector(INTRO_QRCODE_SELECTOR, { timeout: this.options.authTimeoutMs })
@@ -259,7 +261,10 @@ class Client extends EventEmitter {
 
             // Wait for code scan
             try {
-                await page.waitForSelector(INTRO_IMG_SELECTOR, { timeout: 0 });
+                await page.waitForFunction((INTRO_IMG_SELECTOR) => 
+                    !!document.querySelectorAll(INTRO_IMG_SELECTOR).length,
+                    {timeout: 0}, INTRO_IMG_SELECTOR
+                )
             } catch(error) {
                 if (
                     error.name === 'ProtocolError' && 


### PR DESCRIPTION

Fixes #2473, #2479

# PR Details

Added multiple selectors from the logged-in page

## Description

The current and alpha versions refer to [data-icon="chat"] css selector when waiting for authenticated/logged-in page load. WhatsApp has since changed the selector to "new-chat" instead of "chat". This PR adds multiple selectors with wildcard substring selection for the css selectors that are present on the logged-in page.

## Related Issue

<!--- Optional --->
<!--- If there is an issue link it here: -->

## Motivation and Context

<!--- Optional --->
<!--- Why is this change required? What problem does it solve? -->
This will solve the "ready event not firing" issue after QR Code scan.
Should fix : 
https://github.com/pedroslopez/whatsapp-web.js/issues/2479
https://github.com/pedroslopez/whatsapp-web.js/issues/2473

## How Has This Been Tested

Tested locally and private remote server.
Env :
NodeJS v18.15.0
whatsapp-web.js 1.22.2-alpha.0

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Dependency change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (index.d.ts).



